### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "mongodb": "^3.2.7",
     "mongoose": "^5.5.13",
     "nodemon": "^1.19.1",
-    "npm": "^6.9.0",
     "request": "^2.88.0"
   },
   "description": ""


### PR DESCRIPTION

Hello SUTHARRAM!

It seems like you have npm as one of your (dev-) dependency in Weather-app.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
